### PR TITLE
fix incorrect path to trusted root dir

### DIFF
--- a/src/myapp/settings.py
+++ b/src/myapp/settings.py
@@ -62,5 +62,7 @@ TARGET_BASE_URL = 'http://localhost:8000/targets/'
 TRUSTED_ROOT_SRC = MODULE_DIR.parent / 'root.json'
 if not FROZEN:
     # for development, get the root metadata directly from local repo
-    TRUSTED_ROOT_SRC = MODULE_DIR.parent.parent / 'repo/deploy/metadata/root.json'
+    sys.path.insert(0, str(MODULE_DIR.parent.parent))
+    from repo_settings import REPO_DIR
+    TRUSTED_ROOT_SRC =  REPO_DIR / 'metadata' / 'root.json'
 TRUSTED_ROOT_DST = METADATA_DIR / 'root.json'


### PR DESCRIPTION
It's not possible to run the example app in development mode (not frozen):

```
INFO:__main__:my_app 1.8
Traceback (most recent call last):
  File "c:\Projects\tufup-example_aws\src\main.py", line 13, in <module>      
    main(sys.argv[1:])
  File "C:\Projects\tufup-example_aws\src\myapp\__init__.py", line 64, in main
    shutil.copy(src=settings.TRUSTED_ROOT_SRC, dst=settings.TRUSTED_ROOT_DST) 
  File "C:\Python311\Lib\shutil.py", line 419, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "C:\Python311\Lib\shutil.py", line 256, in copyfile
    with open(src, 'rb') as fsrc:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Projects\\tufup-example_aws\\repo\\deploy\\metadata\\root.json'
```

The `TRUSTED_ROOT_SRC` did not point to the path specified by repo_settings.py